### PR TITLE
Interim solution for handling Lambda timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 
 # .tfvars files
 *.tfvars
+receiver/invoker.zip
 receiver/receiver.zip
 .idea/

--- a/config_table.tf
+++ b/config_table.tf
@@ -13,7 +13,8 @@ resource "aws_dynamodb_table" "loader_config" {
 }
 
 resource "aws_dynamodb_table_item" "load_config_full_items" {
-  for_each = toset([for table in jsondecode(data.http.bulk_data_schemas.body)["tables"] : table["table"]["name"]])
+  /*for_each = toset([for table in jsondecode(data.http.bulk_data_schemas.body)["tables"] : table["table"]["name"]])*/
+  for_each = toset([for table in jsondecode(data.http.bulk_data_schemas.body)["tables"] : table["table"]["name"] if table["table"]["name"] != "signatures"])
 
   table_name = aws_dynamodb_table.loader_config.name
   hash_key   = aws_dynamodb_table.loader_config.hash_key
@@ -34,7 +35,8 @@ resource "aws_dynamodb_table_item" "load_config_full_items" {
 }
 
 data "template_file" "loader_config_full_item" {
-  for_each = toset([for table in jsondecode(data.http.bulk_data_schemas.body)["tables"] : table["table"]["name"]])
+  /*for_each = toset([for table in jsondecode(data.http.bulk_data_schemas.body)["tables"] : table["table"]["name"]])*/
+  for_each = toset([for table in jsondecode(data.http.bulk_data_schemas.body)["tables"] : table["table"]["name"] if table["table"]["name"] != "signatures"])
 
   template = "${file("${path.module}/config_item.json")}"
   vars = {

--- a/loader.tf
+++ b/loader.tf
@@ -5,7 +5,8 @@ resource "aws_lambda_function" "loader" {
   role          = aws_iam_role.loader_lambda_role.arn
   handler       = "index.handler"
   runtime       = "nodejs8.10"
-  timeout       = 300
+  memory_size   = 512
+  timeout       = 900
   environment {
     variables = {
       "DEBUG" = "true"
@@ -38,14 +39,14 @@ resource "aws_s3_bucket_notification" "notifications" {
 }
 
 resource "aws_sns_topic" "success_sns_topic" {
-  depends_on = ["aws_lambda_function.loader"]
+  depends_on = [aws_lambda_function.loader]
 
   name = var.success_topic_name
   policy = data.aws_iam_policy_document.success_sns_notification_policy.json
 }
 
 resource "aws_sns_topic" "failure_sns_topic" {
-  depends_on = ["aws_lambda_function.loader"]
+  depends_on = [aws_lambda_function.loader]
 
   name = var.failure_topic_name
   policy = data.aws_iam_policy_document.failure_sns_notification_policy.json

--- a/logs.tf
+++ b/logs.tf
@@ -14,3 +14,11 @@ resource "aws_cloudwatch_log_group" "webhook" {
     Application = "controlshift-redshift"
   }
 }
+
+resource "aws_cloudwatch_log_group" "invoker" {
+  name = "/aws/lambda/controlshift-webhook-handler-invoker"
+  retention_in_days = 5
+  tags = {
+    Application = "controlshift-redshift"
+  }
+}

--- a/receiver.tf
+++ b/receiver.tf
@@ -1,7 +1,29 @@
+data "archive_file" "invoker_zip" {
+  type        = "zip"
+  source_file = "${path.module}/receiver/invoker.js"
+  output_path = "${path.module}/receiver/invoker.zip"
+}
+
 data "archive_file" "receiver_zip" {
   type        = "zip"
   source_file = "${path.module}/receiver/receiver.js"
   output_path = "${path.module}/receiver/receiver.zip"
+}
+
+resource "aws_lambda_function" "invoker_lambda" {
+  filename = data.archive_file.invoker_zip.output_path
+  function_name = "controlshift-webhook-handler-invoker"
+  role          = aws_iam_role.invoker_lambda_role.arn
+  handler       = "invoker.handler"
+  runtime       = "nodejs10.x"
+  timeout       = 30
+  source_code_hash = filebase64sha256(data.archive_file.invoker_zip.output_path)
+
+  environment {
+    variables = {
+      S3_BUCKET = aws_s3_bucket.receiver.bucket
+    }
+  }
 }
 
 resource "aws_lambda_function" "receiver_lambda" {
@@ -10,6 +32,7 @@ resource "aws_lambda_function" "receiver_lambda" {
   role          = aws_iam_role.receiver_lambda_role.arn
   handler       = "receiver.handler"
   runtime       = "nodejs10.x"
+  memory_size   = 256
   timeout       = var.receiver_timeout
   source_code_hash = filebase64sha256(data.archive_file.receiver_zip.output_path)
 
@@ -69,14 +92,14 @@ resource "aws_api_gateway_integration" "request_method_integration" {
   resource_id = aws_api_gateway_resource.webhook.id
   http_method = "POST"
   type        = "AWS_PROXY"
-  uri         = "arn:aws:apigateway:${var.aws_region}:lambda:path/2015-03-31/functions/${aws_lambda_function.receiver_lambda.arn}/invocations"
+  uri         = "arn:aws:apigateway:${var.aws_region}:lambda:path/2015-03-31/functions/${aws_lambda_function.invoker_lambda.arn}/invocations"
   # AWS lambdas can only be invoked with the POST method
   integration_http_method = "POST"
 }
 
 # The * part allows invocation from any stage within API Gateway REST API.
 resource "aws_lambda_permission" "allow_api_gateway" {
-  function_name = aws_lambda_function.receiver_lambda.function_name
+  function_name = aws_lambda_function.invoker_lambda.function_name
   statement_id  = "AllowExecutionFromApiGateway"
   action        = "lambda:InvokeFunction"
   principal     = "apigateway.amazonaws.com"
@@ -85,7 +108,7 @@ resource "aws_lambda_permission" "allow_api_gateway" {
 
 # for now, there is only one deployment
 resource "aws_api_gateway_deployment" "deployment" {
-  depends_on = ["aws_api_gateway_integration.request_method_integration"]
+  depends_on = [aws_api_gateway_integration.request_method_integration]
 
   rest_api_id = aws_api_gateway_rest_api.receiver.id
   stage_name  = "production"

--- a/receiver/invoker.js
+++ b/receiver/invoker.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const aws = require('aws-sdk');
+const lambda = new aws.Lambda({
+  // region: 'us-west-2'
+});
+
+function sendResponse(body) {
+    let response =  {
+        isBase64Encoded: false,
+        statusCode: 200,
+        headers: {'Content-Type': 'application/json', 'x-controlshift-processed': '1'},
+        body: JSON.stringify(body)
+    };
+    console.log("response: " + JSON.stringify(response));
+    return response;
+}
+
+function invokeLambda(payload) {
+  const params = {
+    FunctionName: 'controlshift-webhook-handler',
+    Payload: JSON.stringify(payload),
+    InvocationType: 'Event'
+  };
+
+  return new Promise((resolve, reject) => {
+    lambda.invoke(params, (err, data) => {
+      if (err) {
+        console.log('Error invoking receiver lambda:', err);
+        reject(err);
+      }
+      else {
+        console.log('Successfully invoked receiver with data:', data);
+        resolve(data);
+      }
+    });
+  });
+}
+
+// Lambda event Handler
+exports.handler = async (event) => {
+    let receivedJSON = JSON.parse(event.body);
+    console.log('Received event:', receivedJSON);
+
+    await invokeLambda({ body: receivedJSON });
+
+    return Promise.resolve(sendResponse({"status": "processed", "payload": receivedJSON}));
+};

--- a/receiver/receiver.js
+++ b/receiver/receiver.js
@@ -13,10 +13,10 @@ async function processCsv(downloadUrl, table, kind) {
       const today = new Date();
       const key = `${kind}/${table}/${today.getFullYear()}/${today.getMonth()}/${today.getDate()}/${today.getHours()}-${today.getMinutes()}-${today.getSeconds()}/table.csv`;
       await copyToS3(downloadUrl, key);
-      console.log("Successfully copied")
+      console.log(`Successfully copied ${downloadUrl} to ${key}`)
     }
     catch(err){
-      console.log(`Failed: ${err.message}`)
+      console.log(`Failed: ${err.message} (${downloadUrl})`)
     }
     finally{
       return sendResponse({"status": "processed"})
@@ -55,7 +55,8 @@ function sendResponse(body) {
 
 // Lambda event Handler
 exports.handler = async (event) => {
-    let receivedJSON = JSON.parse(event.body);
+    // let receivedJSON = JSON.parse(event.body);
+    let receivedJSON = event.body;
     console.log('Received event:', receivedJSON);
     if(receivedJSON.type === 'data.full_table_exported'){
         return processCsv(receivedJSON.data.url, receivedJSON.data.table, 'full');


### PR DESCRIPTION
* Temporarily skip syncing of the full `signatures` table.
* Implement an intermediate Lambda that is called by the API Gateway. This Lambda invokes the actual receiver Lambda asynchronously, so that the API Gateway can return immediately, and the receiver Lambda can continue to execute beyond the 29-second API Gateway-Lambda integration timeout hard limit.