### PR TITLE
Allow for multiple instances of loader_lambda_role

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -97,7 +97,7 @@ resource "aws_iam_role_policy_attachment" "gateway_cloudwatch_logging" {
 }
 
 resource "aws_iam_role" "loader_lambda_role" {
-  name = "LoaderLambdaRole"
+  name_prefix = "LoaderLambdaRole"
   description = "Used by the controlshift-redshift-loader Lambda for processing db replication data from ControlShift into Redshift"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }


### PR DESCRIPTION
The loader lambda role references specific DynamoDB resources, so unlike the other two lambda roles created in iam.tf, you can't just reuse the existing role for a new instance of the sync.  Allowing for multiple instances by switching to name_prefix makes it possible to sync to separate Redshift databases in separate regions (though still only one sync can run per region).