### PR TITLE
Truncate strings that are too large to fit

### DIFF
--- a/config_item.json
+++ b/config_item.json
@@ -12,7 +12,7 @@
       "truncateTarget": {"BOOL": ${truncate_target}},
       "useSSL": {"BOOL": false}
     }}]},
-  "copyOptions": {"S": "EMPTYASNULL"},
+  "copyOptions": {"S": "EMPTYASNULL TRUNCATECOLUMNS"},
   "dataFormat": {"S": "CSV"},
   "csvDelimiter": {"S": ","},
   "ignoreCsvHeader": {"BOOL": true},


### PR DESCRIPTION
Fix the error 'String length exceeds DDL length' by truncating anything that's too long.

TESTED: Manual update of blast_emails config in DynamoDB.