### PR TITLE
Disable loader debug

### DIFF
--- a/loader.tf
+++ b/loader.tf
@@ -7,11 +7,6 @@ resource "aws_lambda_function" "loader" {
   runtime       = "nodejs10.x"
   memory_size   = 512
   timeout       = 900
-  environment {
-    variables = {
-      "DEBUG" = "true"
-    }
-  }
 }
 
 resource "aws_lambda_permission" "allow_bucket" {


### PR DESCRIPTION
For some reason DEBUG=true has started throwing exceptions (erroneously trying to read a line from the config that's not required to be there)