### PR TITLE
Don't return nonexistent resp (#22)

### DIFF
--- a/lambdas/receiver.js
+++ b/lambdas/receiver.js
@@ -46,7 +46,6 @@ function enqueueTask(receivedData, kind) {
       console.log("Error", error);
     }
   );
-  return resp
 }
 
 function sendResponse(body) {


### PR DESCRIPTION
In enqueueTask, 'resp' is no longer defined because we now have two separate queues.