### PR TITLE
2023feb  terraform updates

### DIFF
--- a/glue_job.tf
+++ b/glue_job.tf
@@ -28,6 +28,18 @@ resource "aws_s3_bucket" "glue_resources" {
       }
     }
   }
+
+  lifecycle_rule {
+    id      = "Remove temp files over a week old"
+    abort_incomplete_multipart_upload_days = 0
+    enabled = true
+    prefix = "production/temp/"
+
+    expiration {
+      days = 7
+      expired_object_delete_marker = false
+    }
+  }
 }
 
 data "template_file" "signatures_script" {

--- a/glue_job.tf
+++ b/glue_job.tf
@@ -10,6 +10,14 @@ resource "aws_glue_crawler" "signatures_crawler" {
   database_name = aws_glue_catalog_database.catalog_db.name
   name = "${var.controlshift_environment}_full_signatures"
   role = aws_iam_role.glue_service_role.arn
+  configuration = jsonencode(
+      {
+        Grouping = {
+            TableGroupingPolicy = "CombineCompatibleSchemas"
+          }
+        Version  = 1
+      }
+  )
 
   s3_target {
     path = local.signatures_s3_path
@@ -146,6 +154,8 @@ resource "aws_glue_job" "signatures_full" {
   name = "cs-${var.controlshift_environment}-signatures-full"
   connections = [ aws_glue_connection.redshift_connection.name ]
   glue_version = "3.0"
+  number_of_workers = 9
+  worker_type = "G.1X"
   default_arguments = {
     "--TempDir": "s3://${aws_s3_bucket.glue_resources.bucket}/${var.controlshift_environment}/temp",
     "--job-bookmark-option": "job-bookmark-disable",

--- a/receiver.tf
+++ b/receiver.tf
@@ -21,6 +21,11 @@ resource "aws_lambda_function" "receiver_lambda" {
       EMAIL_CLICK_FIREHOSE_STREAM = var.email_click_firehose_stream
     }
   }
+
+  // This prevents noisy logs from cluttering up datadog
+  tags = {
+    datadog = "exclude"
+  }
 }
 
 resource "aws_api_gateway_rest_api" "receiver" {

--- a/s3.tf
+++ b/s3.tf
@@ -24,14 +24,13 @@ resource "aws_s3_bucket" "manifest" {
   # expire the ingested manifests after 5 days after they have been processed to save disk space while providing enough
   # time to analyze things that might have gone wrong.
   lifecycle_rule {
-    id      = "Remove temp files over a week old"
-    abort_incomplete_multipart_upload_days = 0
+    id      = "expire-manifests"
     enabled = true
-    prefix = "production/temp/"
 
     expiration {
-      days = 7
-      expired_object_delete_marker = false
+      days = 5
     }
   }
 }
+
+

--- a/s3.tf
+++ b/s3.tf
@@ -24,13 +24,14 @@ resource "aws_s3_bucket" "manifest" {
   # expire the ingested manifests after 5 days after they have been processed to save disk space while providing enough
   # time to analyze things that might have gone wrong.
   lifecycle_rule {
-    id      = "expire-manifests"
+    id      = "Remove temp files over a week old"
+    abort_incomplete_multipart_upload_days = 0
     enabled = true
+    prefix = "production/temp/"
 
     expiration {
-      days = 5
+      days = 7
+      expired_object_delete_marker = false
     }
   }
 }
-
-


### PR DESCRIPTION
All of these updates were made to create parity between the attributes we have manually added through the aws console and the terraform deploy. I have not tried deploying this (but will once I get approval) but I created it by running `terraform plan` in the [csl pipeline deployment repo](https://github.com/MoveOnOrg/csl-replication-pipeline) which is basically a deployable wrapper around this repo then seeing what it was marking as different between what we have now and asking sophie and exploring myself to check that we actually did want to keep those changes.

Then i went into that repo and changed the source package to:
`source = "git@github.com:MoveOnOrg/terraform-aws-controlshift-redshift-sync.git?ref=2023feb--terraform-updates"`
and ran `terraform plan` again to check that none of those things were being modified anymore.