### PR TITLE
Upgrade AWS provider version

### DIFF
--- a/glue_job.tf
+++ b/glue_job.tf
@@ -26,7 +26,6 @@ resource "aws_glue_crawler" "signatures_crawler" {
 
 resource "aws_s3_bucket" "glue_resources" {
   bucket = var.glue_scripts_bucket_name
-  region = var.aws_region
 
   acl = "private"
   server_side_encryption_configuration {

--- a/s3.tf
+++ b/s3.tf
@@ -8,7 +8,6 @@ resource "aws_s3_bucket" "manifest" {
   provider = aws.controlshift
   bucket = var.manifest_bucket_name
   acl    = "private"
-  region = var.controlshift_aws_region
 
   server_side_encryption_configuration {
     rule {

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
     http = {
       source = "hashicorp/http"

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source = "hashicorp/aws"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     http = {
       source = "hashicorp/http"


### PR DESCRIPTION
Upgrade AWS provider version to 4.0 and make required changes. Note that this upgrade and changes have already previously been made to the [upstream repo](https://github.com/controlshift/terraform-aws-controlshift-redshift-sync).