### PR TITLE
Downgrade to Nodejs 16.x

### DIFF
--- a/loader.tf
+++ b/loader.tf
@@ -4,7 +4,7 @@ resource "aws_lambda_function" "loader" {
   function_name = "controlshift-redshift-loader"
   role          = aws_iam_role.loader_lambda_role.arn
   handler       = "index.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs16.x"
   timeout       = 900
 
   vpc_config {

--- a/receiver.tf
+++ b/receiver.tf
@@ -9,7 +9,7 @@ resource "aws_lambda_function" "receiver_lambda" {
   function_name = "controlshift-webhook-handler"
   role          = aws_iam_role.receiver_lambda_role.arn
   handler       = "receiver.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs16.x"
   timeout       = var.receiver_timeout
   source_code_hash = data.archive_file.receiver_zip.output_base64sha256
 

--- a/run_glue_crawler.tf
+++ b/run_glue_crawler.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_function" "glue_crawler_lambda" {
   function_name = "controlshift-run-glue-crawler"
   role          = aws_iam_role.run_glue_crawler_lambda_role.arn
   handler       = "run-glue-crawler.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs16.x"
   timeout       = 60
   source_code_hash = data.archive_file.run_glue_crawler_zip.output_base64sha256
 

--- a/run_glue_job.tf
+++ b/run_glue_job.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_function" "glue_job_lambda" {
   function_name = "controlshift-run-glue-job"
   role          = aws_iam_role.run_glue_job_lambda_role.arn
   handler       = "run-glue-job.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs16.x"
   timeout       = 60
   source_code_hash = data.archive_file.run_glue_job_zip.output_base64sha256
 


### PR DESCRIPTION
AWS in their infinite wisdom removed their old SDK from the node 18 and 20 environments, requiring an upgrade to their new SDK.  This meant that the Lambda would crash when it tried to load the old SDK.  Revert back to nodejs 16 to avoid this issue.