### PR TITLE
Update minimum required Terraform version and resolve various deprecation notices

### DIFF
--- a/config_table.tf
+++ b/config_table.tf
@@ -13,12 +13,12 @@ resource "aws_dynamodb_table" "loader_config" {
 }
 
 resource "aws_dynamodb_table_item" "load_config_full_items" {
-  for_each = toset([for table in local.parsed_bulk_data_schemas["tables"] : table["table"]["name"]])
+  for_each = toset(local.table_names)
 
   table_name = aws_dynamodb_table.loader_config.name
   hash_key   = aws_dynamodb_table.loader_config.hash_key
 
-  item = data.template_file.loader_config_full_item[each.key].rendered
+  item = local.loader_config_full_items[each.key]
 
   lifecycle {
     ignore_changes = [
@@ -30,42 +30,16 @@ resource "aws_dynamodb_table_item" "load_config_full_items" {
 
       item
     ]
-  }
-}
-
-data "template_file" "loader_config_full_item" {
-  for_each = toset([for table in local.parsed_bulk_data_schemas["tables"] : table["table"]["name"]])
-
-  template = "${file("${path.module}/config_item.json")}"
-  vars = {
-    kind = "full"
-    bulk_data_table = each.key
-    redshift_endpoint = data.aws_redshift_cluster.sync_data_target.endpoint
-    redshift_database_name: var.redshift_database_name
-    redshift_port = data.aws_redshift_cluster.sync_data_target.port
-    redshift_username = var.redshift_username
-    redshift_password = aws_kms_ciphertext.redshift_password.ciphertext_blob
-    schema = var.redshift_schema
-    s3_bucket = "agra-data-exports-${var.controlshift_environment}"
-    manifest_bucket = aws_s3_bucket.manifest.bucket
-    manifest_prefix = var.manifest_prefix
-    failed_manifest_prefix = var.failed_manifest_prefix
-    success_topic_arn = aws_sns_topic.success_sns_topic.arn
-    failure_topic_arn = aws_sns_topic.failure_sns_topic.arn
-    current_batch = random_id.current_batch.b64_url
-    column_list = data.http.column_list[each.key].body
-    truncate_target = true
-    compress = try(local.parsed_bulk_data_schemas["settings"]["compression_format"], "")
   }
 }
 
 resource "aws_dynamodb_table_item" "load_config_incremental_items" {
-  for_each = toset([for table in local.parsed_bulk_data_schemas["tables"] : table["table"]["name"]])
+  for_each = toset(local.table_names)
 
   table_name = aws_dynamodb_table.loader_config.name
   hash_key   = aws_dynamodb_table.loader_config.hash_key
 
-  item = data.template_file.loader_config_incremental_item[each.key].rendered
+  item = local.loader_config_incremental_items[each.key]
 
   lifecycle {
     ignore_changes = [
@@ -80,29 +54,53 @@ resource "aws_dynamodb_table_item" "load_config_incremental_items" {
   }
 }
 
-data "template_file" "loader_config_incremental_item" {
-  for_each = toset([for table in local.parsed_bulk_data_schemas["tables"] : table["table"]["name"]])
+locals {
+  table_names = [for table in local.parsed_bulk_data_schemas["tables"] : table["table"]["name"]]
 
-  template = "${file("${path.module}/config_item.json")}"
-  vars = {
-    kind = "incremental"
-    bulk_data_table = each.key
-    redshift_endpoint = data.aws_redshift_cluster.sync_data_target.endpoint
-    redshift_database_name: var.redshift_database_name
-    redshift_port = data.aws_redshift_cluster.sync_data_target.port
-    redshift_username = var.redshift_username
-    redshift_password = aws_kms_ciphertext.redshift_password.ciphertext_blob
-    schema = var.redshift_schema
-    s3_bucket = "agra-data-exports-${var.controlshift_environment}"
-    manifest_bucket = aws_s3_bucket.manifest.bucket
-    manifest_prefix = var.manifest_prefix
-    failed_manifest_prefix = var.failed_manifest_prefix
-    success_topic_arn = aws_sns_topic.success_sns_topic.arn
-    failure_topic_arn = aws_sns_topic.failure_sns_topic.arn
-    current_batch = random_id.current_batch.b64_url
-    column_list = data.http.column_list[each.key].body
-    truncate_target = false
-    compress = try(local.parsed_bulk_data_schemas["settings"]["compression_format"], "")
+  loader_config_full_items = {
+    for name in local.table_names : name => templatefile("${path.module}/config_item.json", {
+      kind = "full"
+      bulk_data_table = name
+      redshift_endpoint = data.aws_redshift_cluster.sync_data_target.endpoint
+      redshift_database_name: var.redshift_database_name
+      redshift_port = data.aws_redshift_cluster.sync_data_target.port
+      redshift_username = var.redshift_username
+      redshift_password = aws_kms_ciphertext.redshift_password.ciphertext_blob
+      schema = var.redshift_schema
+      s3_bucket = "agra-data-exports-${var.controlshift_environment}"
+      manifest_bucket = aws_s3_bucket.manifest.bucket
+      manifest_prefix = var.manifest_prefix
+      failed_manifest_prefix = var.failed_manifest_prefix
+      success_topic_arn = aws_sns_topic.success_sns_topic.arn
+      failure_topic_arn = aws_sns_topic.failure_sns_topic.arn
+      current_batch = random_id.current_batch.b64_url
+      column_list = data.http.column_list[name].body
+      truncate_target = true
+      compress = try(local.parsed_bulk_data_schemas["settings"]["compression_format"], "")
+    })
+  }
+
+  loader_config_incremental_items = {
+    for name in local.table_names : name => templatefile("${path.module}/config_item.json", {
+      kind = "incremental"
+      bulk_data_table = name
+      redshift_endpoint = data.aws_redshift_cluster.sync_data_target.endpoint
+      redshift_database_name: var.redshift_database_name
+      redshift_port = data.aws_redshift_cluster.sync_data_target.port
+      redshift_username = var.redshift_username
+      redshift_password = aws_kms_ciphertext.redshift_password.ciphertext_blob
+      schema = var.redshift_schema
+      s3_bucket = "agra-data-exports-${var.controlshift_environment}"
+      manifest_bucket = aws_s3_bucket.manifest.bucket
+      manifest_prefix = var.manifest_prefix
+      failed_manifest_prefix = var.failed_manifest_prefix
+      success_topic_arn = aws_sns_topic.success_sns_topic.arn
+      failure_topic_arn = aws_sns_topic.failure_sns_topic.arn
+      current_batch = random_id.current_batch.b64_url
+      column_list = data.http.column_list[name].body
+      truncate_target = false
+      compress = try(local.parsed_bulk_data_schemas["settings"]["compression_format"], "")
+    })
   }
 }
 
@@ -134,11 +132,11 @@ data "http" "bulk_data_schemas" {
 }
 
 locals {
-  parsed_bulk_data_schemas = jsondecode(data.http.bulk_data_schemas.body)
+  parsed_bulk_data_schemas = jsondecode(data.http.bulk_data_schemas.response_body)
 }
 
 data "http" "column_list" {
-  for_each = toset([for table in local.parsed_bulk_data_schemas["tables"] : table["table"]["name"]])
+  for_each = toset(local.table_names)
 
   url = "https://${var.controlshift_hostname}/api/bulk_data/schema/columns?table=${each.key}"
 }

--- a/config_table.tf
+++ b/config_table.tf
@@ -62,7 +62,7 @@ locals {
       kind = "full"
       bulk_data_table = name
       redshift_endpoint = data.aws_redshift_cluster.sync_data_target.endpoint
-      redshift_database_name: var.redshift_database_name
+      redshift_database_name = var.redshift_database_name
       redshift_port = data.aws_redshift_cluster.sync_data_target.port
       redshift_username = var.redshift_username
       redshift_password = aws_kms_ciphertext.redshift_password.ciphertext_blob
@@ -85,7 +85,7 @@ locals {
       kind = "incremental"
       bulk_data_table = name
       redshift_endpoint = data.aws_redshift_cluster.sync_data_target.endpoint
-      redshift_database_name: var.redshift_database_name
+      redshift_database_name = var.redshift_database_name
       redshift_port = data.aws_redshift_cluster.sync_data_target.port
       redshift_username = var.redshift_username
       redshift_password = aws_kms_ciphertext.redshift_password.ciphertext_blob

--- a/glue_job.tf
+++ b/glue_job.tf
@@ -26,45 +26,69 @@ resource "aws_glue_crawler" "signatures_crawler" {
 
 resource "aws_s3_bucket" "glue_resources" {
   bucket = var.glue_scripts_bucket_name
+}
 
-  acl = "private"
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
+# Ownership controls block is required to support ACLs.
+resource "aws_s3_bucket_ownership_controls" "glue_resources" {
+  bucket = aws_s3_bucket.glue_resources.id
+  rule {
+    object_ownership = "ObjectWriter"
   }
+}
 
-  lifecycle_rule {
-    id      = "Remove temp files over a week old"
-    abort_incomplete_multipart_upload_days = 0
-    enabled = true
-    prefix = "production/temp/"
+resource "aws_s3_bucket_acl" "glue_resources" {
+  depends_on = [aws_s3_bucket_ownership_controls.glue_resources]
 
-    expiration {
-      days = 7
-      expired_object_delete_marker = false
+  bucket = aws_s3_bucket.glue_resources.id
+  acl = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "glue_resources" {
+  bucket = aws_s3_bucket.glue_resources.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }
 
-data "template_file" "signatures_script" {
-  template = file("${path.module}/templates/signatures_job.py.tpl")
-  vars = {
+resource "aws_s3_bucket_lifecycle_configuration" "glue_resources" {
+  bucket = aws_s3_bucket.glue_resources.id
+
+  rule {
+    id = "Remove temp files over a week old"
+    status = "Enabled"
+
+    filter {
+      prefix = "production/temp/"
+    }
+
+    expiration {
+      days = 7
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7 # Note: must be greater than 0
+    }
+  }
+}
+
+locals {
+  signatures_script = templatefile("${path.module}/templates/signatures_job.py.tpl", {
     catalog_database_name = aws_glue_catalog_database.catalog_db.name
     redshift_database_name = var.redshift_database_name
     redshift_schema = var.redshift_schema
     redshift_connection_name = aws_glue_connection.redshift_connection.name
-  }
+  })
 }
 
-resource "aws_s3_bucket_object" "signatures_script" {
+resource "aws_s3_object" "signatures_script" {
   bucket = aws_s3_bucket.glue_resources.id
   key = "${var.controlshift_environment}/signatures_job.py"
   acl = "private"
 
-  content = data.template_file.signatures_script.rendered
+  content = local.signatures_script
 }
 
 resource "aws_iam_role" "glue_service_role" {

--- a/s3.tf
+++ b/s3.tf
@@ -6,7 +6,7 @@ provider "aws" {
 
 resource "aws_s3_bucket" "manifest" {
   provider = aws.controlshift
-  bucket   = var.manifest_bucket_name
+  bucket = var.manifest_bucket_name
 
   tags = {
     Name = "ControlShift puts import manifests here"
@@ -16,37 +16,20 @@ resource "aws_s3_bucket" "manifest" {
 # Ownership controls block is required to support ACLs.
 resource "aws_s3_bucket_ownership_controls" "manifest" {
   provider = aws.controlshift
-  bucket   = aws_s3_bucket.manifest.id
+  bucket = aws_s3_bucket.manifest.id
   rule {
     object_ownership = "ObjectWriter"
   }
 }
 
-resource "aws_s3_bucket_acl" "manifest" {
-  provider   = aws.controlshift
-  depends_on = [aws_s3_bucket_ownership_controls.manifest]
-
-  bucket = aws_s3_bucket.manifest.id
-  acl    = "private"
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "manifest" {
-  provider = aws.controlshift
-  bucket   = aws_s3_bucket.manifest.id
-
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
-    }
-  }
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "manifest" {
   provider = aws.controlshift
-  bucket   = aws_s3_bucket.manifest.id
+  bucket = aws_s3_bucket.manifest.id
 
+  # expire the ingested manifests after 5 days after they have been processed to save disk space while providing enough
+  # time to analyze things that might have gone wrong.
   rule {
-    id     = "expire-manifests"
+    id = "expire-manifests"
     status = "Enabled"
 
     expiration {
@@ -55,5 +38,24 @@ resource "aws_s3_bucket_lifecycle_configuration" "manifest" {
 
     # Best practice: filter is now required inside the rule block
     filter {}
+  }
+}
+
+resource "aws_s3_bucket_acl" "manifest" {
+  provider = aws.controlshift
+  depends_on = [aws_s3_bucket_ownership_controls.manifest]
+
+  bucket = aws_s3_bucket.manifest.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "manifest" {
+  provider = aws.controlshift
+  bucket = aws_s3_bucket.manifest.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
   }
 }

--- a/s3.tf
+++ b/s3.tf
@@ -6,30 +6,54 @@ provider "aws" {
 
 resource "aws_s3_bucket" "manifest" {
   provider = aws.controlshift
-  bucket = var.manifest_bucket_name
-  acl    = "private"
+  bucket   = var.manifest_bucket_name
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
   tags = {
     Name = "ControlShift puts import manifests here"
   }
+}
 
-  # expire the ingested manifests after 5 days after they have been processed to save disk space while providing enough
-  # time to analyze things that might have gone wrong.
-  lifecycle_rule {
-    id      = "expire-manifests"
-    enabled = true
+# Ownership controls block is required to support ACLs.
+resource "aws_s3_bucket_ownership_controls" "manifest" {
+  provider = aws.controlshift
+  bucket   = aws_s3_bucket.manifest.id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
 
-    expiration {
-      days = 5
+resource "aws_s3_bucket_acl" "manifest" {
+  provider   = aws.controlshift
+  depends_on = [aws_s3_bucket_ownership_controls.manifest]
+
+  bucket = aws_s3_bucket.manifest.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "manifest" {
+  provider = aws.controlshift
+  bucket   = aws_s3_bucket.manifest.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "manifest" {
+  provider = aws.controlshift
+  bucket   = aws_s3_bucket.manifest.id
 
+  rule {
+    id     = "expire-manifests"
+    status = "Enabled"
+
+    expiration {
+      days = 5
+    }
+
+    # Best practice: filter is now required inside the rule block
+    filter {}
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.4.5"
   required_providers {
     archive = {
       source = "hashicorp/archive"
@@ -13,9 +13,6 @@ terraform {
     }
     random = {
       source = "hashicorp/random"
-    }
-    template = {
-      source = "hashicorp/template"
     }
   }
 }


### PR DESCRIPTION
In order to update the AWS provider version (see the note at the bottom), we need to use a newer version of Terraform (1.4.5). However, this version doesn't support the deprecated `hashicorp/template` provider on non-Intel Macs. (See discussions [here](https://github.com/hashicorp/terraform/issues/33388) and [here](https://github.com/hashicorp/terraform-provider-template/issues/85).) A temporary workaround is to install the Intel version of Terraform, but this is annoying to set up, and the deprecated code needs to be updated anyway.

This PR makes the following changes:
- [x] Replace the use of the `template_file` provider with the built-in `templatefile` function.
- [x] Update S3 bucket configurations to use the new format, which splits the configuration into different resource blocks.

Some of these changes already existed upstream. The others were added in https://github.com/controlshift/terraform-aws-controlshift-redshift-sync/pull/41

Due to the change in how the S3 bucket resources are defined, we need to run the following import commands BEFORE `terraform apply` so that Terraform knows these resources already exist (otherwise it will try to delete and recreate them). Note: `GLUE_SCRIPTS_BUCKET_NAME` and `MANIFEST_BUCKET_NAME` must be replaced with the actual S3 bucket names.

```
terraform import module.terraform-aws-controlshift-redshift-sync.aws_s3_bucket_acl.glue_resources GLUE_SCRIPTS_BUCKET_NAME
terraform import module.terraform-aws-controlshift-redshift-sync.aws_s3_bucket_server_side_encryption_configuration.glue_resources GLUE_SCRIPTS_BUCKET_NAME
terraform import module.terraform-aws-controlshift-redshift-sync.aws_s3_bucket_lifecycle_configuration.glue_resources GLUE_SCRIPTS_BUCKET_NAME
terraform import module.terraform-aws-controlshift-redshift-sync.aws_s3_object.signatures_script GLUE_SCRIPTS_BUCKET_NAME/production/signatures_job.py

terraform import module.terraform-aws-controlshift-redshift-sync.aws_s3_bucket_acl.manifest MANIFEST_BUCKET_NAME
terraform import module.terraform-aws-controlshift-redshift-sync.aws_s3_bucket_server_side_encryption_configuration.manifest MANIFEST_BUCKET_NAME
terraform import module.terraform-aws-controlshift-redshift-sync.aws_s3_bucket_lifecycle_configuration.manifest MANIFEST_BUCKET_NAME
```

The import commands update the Terraform state file that is saved in S3 and which represents the current state of the deployed infrastructure. After running the imports, run `terraform plan` and check the following:
- There should be `0 to destroy`
- The `aws_s3_bucket` resources should show `~ update in-place`

If you want to examine the state file itself, you can use `terraform state list` to list the resources addresses and `terraform state show [RESOURCE_ADDRESS]` to show the state details for the given resource.

--

Items to be implemented separately due to their complexity:

- Sync any changes from upstream that we want to include. In particular, the change to the signatures job template file (and the related changes in `glue_job.tf`) would be nice to have.
- Update the AWS provider to "~> 5.26.0" and the Node.js version on the four lambdas. This may be tricky; see details below:
  - The AWS provider version needed to be updated in order to support a newer version of Node.js (see PR https://github.com/MoveOnOrg/terraform-aws-controlshift-redshift-sync/pull/19). The lambdas in this repo are using 16.x, which [AWS has deprecated](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated). Updates will no longer be allowed after July 1, 2026.
  - Previous PRs attempted to update to [Update Node to version 20](https://github.com/MoveOnOrg/terraform-aws-controlshift-redshift-sync/pull/18) but then [downgraded back to version 16](https://github.com/MoveOnOrg/terraform-aws-controlshift-redshift-sync/pull/20). It seems that the lambdas need to be updated to a new version of the AWS SDK.
  - It's also not clear how https://github.com/MoveOnOrg/terraform-aws-controlshift-redshift-sync/pull/21 is related. It updates the AWSLambdaRedshiftLoader from version 2.7.8 to version 2.8.3, but [this repo](https://github.com/awslabs/aws-lambda-redshift-loader) lists 2.7.8 as the latest release so it might not be the correct source.